### PR TITLE
fixed custom route binding fields produce valid path templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-07-04
+
+### Added
+
+- **Multipart request bodies in Postman export.** `multipart/form-data` request
+  bodies now export as Postman `formdata`, with binary and array-of-binary
+  properties emitted as `file` fields and the remaining properties emitted as
+  sampled `text` fields.
+- **Path-template validation in `OpenApiValidator`.** The validator now reports
+  duplicate `operationId`s and path-template mismatches — path parameters that
+  are declared but missing from the template, template placeholders with no
+  matching parameter, and parameter names that aren't valid OpenAPI path names.
+
+### Fixed
+
+- **Custom route binding fields produce valid path templates.** Routes with
+  explicit binding fields such as `{product:slug}` (and typed constraints) are
+  now normalized to `{product}` in OpenAPI paths and Postman URLs, and the path
+  parameter is still extracted, instead of emitting an invalid path template.
+- **Duplicate `operationId`s are made unique.** When several routes resolve to
+  the same controller action, generated `operationId`s now receive a numeric
+  suffix so each operation stays unique, as OpenAPI requires.
+- **Responses keep both schema and example.** A `#[Response]` that supplies a
+  schema (or a `type` string) together with an `example` now emits both under
+  the media type; previously the example replaced the schema.
+- **Nullable union types sample correctly.** `SchemaSampler` now resolves
+  array-typed `type` values such as `['string', 'null']` to their first
+  non-null type, so generated examples and Postman bodies no longer collapse
+  nullable fields to `null`.
+- **Cookie parameters work in the built-in "try it" console.** Documented
+  cookie parameters on same-origin requests are now applied through the browser
+  cookie jar (`document.cookie` with `credentials: 'include'`) instead of an
+  illegal `Cookie` request header that browsers silently drop.
+- **Nested multipart fields use Laravel bracket names.** Try-it requests and
+  request snippets now expand nested arrays and objects in `multipart/form-data`
+  bodies into bracketed field names such as `items[0][sku]`.
+- **Postman export handles an empty security-scheme map.** `components.securitySchemes`
+  serialized as an empty JSON object (`{}`) is coerced back to an array before
+  the Postman auth helpers read it, avoiding a type error.
+
 ## [1.6.1] - 2026-07-04
 
 ### Changed
@@ -285,7 +325,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (with a Scalar driver), Postman export, and the `documentator:generate`,
   `documentator:export` and `documentator:postman` commands.
 
-[Unreleased]: https://github.com/tsitsishvili/documentator/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/tsitsishvili/documentator/compare/v1.6.2...HEAD
+[1.6.2]: https://github.com/tsitsishvili/documentator/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/tsitsishvili/documentator/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/tsitsishvili/documentator/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/tsitsishvili/documentator/compare/v1.4.0...v1.5.0

--- a/docs/built-in-ui-code-map.md
+++ b/docs/built-in-ui-code-map.md
@@ -66,7 +66,7 @@ Opening `http://localhost:8123/` returns 404 because the package root does not h
 | `documentation surface` | Renders the selected endpoint docs: path, summary, params, request body, responses, headers, examples.                                  |
 | `console`               | Builds the right-side request form, reads form values, handles repeatable fields/files/body JSON, and produces normalized request data. |
 | `clipboard`             | Copy helper used by links, snippets, and responses.                                                                                     |
-| `send`                  | Sends live requests with `fetch`, builds multipart/json bodies, and renders response or error output.                                   |
+| `send`                  | Sends live requests with `fetch`, builds multipart/json bodies, applies same-origin cookie parameters, and renders response or error output. |
 | `boot`                  | Fetches the OpenAPI JSON and starts rendering.                                                                                          |
 
 ## Common Change Finder

--- a/resources/ui/core.js
+++ b/resources/ui/core.js
@@ -1579,6 +1579,23 @@ export function start(deps) {
         }
     }
 
+    function appendMultipartField(fields, name, value) {
+        if (Array.isArray(value)) {
+            value.forEach(function (item, index) {
+                appendMultipartField(fields, name + '[' + index + ']', item);
+            });
+            return;
+        }
+        if (value && typeof value === 'object') {
+            Object.keys(value).forEach(function (key) {
+                appendMultipartField(fields, name + '[' + key + ']', value[key]);
+            });
+            return;
+        }
+
+        fields.push({ name: name, value: value === null ? '' : String(value) });
+    }
+
     /* Read the body fields into a normalized shape the senders/snippets understand:
        { mode: 'none' | 'json' | 'raw' | 'multipart', ... }. */
     function readBody(form, content) {
@@ -1615,10 +1632,14 @@ export function start(deps) {
                 json[name] = val;
             }
             hasJson = true;
-            fields.push({
-                name: input.dataset.array === 'true' ? queryArrayName(name) : name,
-                value: typeof val === 'string' ? val : JSON.stringify(val),
-            });
+            if (multipart) {
+                appendMultipartField(fields, input.dataset.array === 'true' ? queryArrayName(name) : name, val);
+            } else {
+                fields.push({
+                    name: input.dataset.array === 'true' ? queryArrayName(name) : name,
+                    value: typeof val === 'string' ? val : JSON.stringify(val),
+                });
+            }
         });
 
         if (multipart) return { mode: 'multipart', fields: fields, files: files };
@@ -1714,6 +1735,21 @@ export function start(deps) {
 
     /* ---------- send ---------- */
 
+    function applyBrowserCookies(url, cookieHeader) {
+        if (!cookieHeader) return false;
+
+        var target;
+        try { target = new URL(url, location.href); } catch (e) { return false; }
+        if (target.origin !== location.origin) return false;
+
+        cookieHeader.split(';').forEach(function (pair) {
+            pair = pair.trim();
+            if (pair) document.cookie = pair + '; Path=/; SameSite=Lax';
+        });
+
+        return true;
+    }
+
     function send() {
         var req = readForm();
         var btn = document.getElementById('send');
@@ -1734,6 +1770,11 @@ export function start(deps) {
 
         var options = { method: req.method.toUpperCase(), headers: {} };
         Object.keys(req.headers).forEach(function (k) { options.headers[k] = req.headers[k]; });
+        if (options.headers.Cookie) {
+            applyBrowserCookies(req.url, options.headers.Cookie);
+            delete options.headers.Cookie;
+            options.credentials = 'include';
+        }
 
         var b = req.body;
         if (b.mode === 'json') {

--- a/src/Extraction/Strategies/ExtractRouteMetadata.php
+++ b/src/Extraction/Strategies/ExtractRouteMetadata.php
@@ -137,7 +137,7 @@ final class ExtractRouteMetadata implements ExtractionStrategy
      */
     private function pathParameters(string $uri): array
     {
-        preg_match_all('/\{(\w+?)(\?)?\}/', $uri, $matches, PREG_SET_ORDER);
+        preg_match_all('/\{(\w+)(?::[^}?]+)?(\?)?\}/', $uri, $matches, PREG_SET_ORDER);
 
         $params = [];
 

--- a/src/OpenApi/OpenApiGenerator.php
+++ b/src/OpenApi/OpenApiGenerator.php
@@ -25,6 +25,9 @@ final class OpenApiGenerator
     /** @var array<string, array<string, mixed>> */
     private array $componentSchemas = [];
 
+    /** @var array<string, int> */
+    private array $operationIds = [];
+
     /**
      * @param  array<int, EndpointData>  $endpoints
      * @return array<string, mixed>
@@ -34,6 +37,7 @@ final class OpenApiGenerator
         $this->componentCounts = $this->componentCounts($endpoints);
         $this->componentNames = [];
         $this->componentSchemas = [];
+        $this->operationIds = [];
 
         $paths = [];
         $tags = [];
@@ -134,7 +138,7 @@ final class OpenApiGenerator
     private function operation(EndpointData $endpoint, string $tag, ?string $globalScheme = null): array
     {
         $operation = array_filter([
-            'operationId' => $endpoint->operationId(),
+            'operationId' => $this->operationId($endpoint),
             'tags' => [$tag],
             'summary' => $endpoint->summary,
             'description' => $endpoint->description,
@@ -157,6 +161,15 @@ final class OpenApiGenerator
         }
 
         return $operation;
+    }
+
+    private function operationId(EndpointData $endpoint): string
+    {
+        $base = $endpoint->operationId();
+        $count = $this->operationIds[$base] ?? 0;
+        $this->operationIds[$base] = $count + 1;
+
+        return $count === 0 ? $base : $base.($count + 1);
     }
 
     /**
@@ -326,15 +339,22 @@ final class OpenApiGenerator
         $body = ['description' => $description];
 
         $mediaType = $response->mediaType ?? 'application/json';
+        $content = [];
+
+        if ($response->schema !== null) {
+            $content['schema'] = $this->responseSchema($response);
+        } elseif ($response->type !== null && ($typeSchema = TypeStringParser::parse($response->type)) !== null) {
+            $content['schema'] = $this->normalizeSchema($typeSchema);
+        } elseif ($response->resource !== null) {
+            $content['schema'] = ['type' => 'object'];
+        }
 
         if ($response->example !== null) {
-            $body['content'] = [$mediaType => ['example' => $response->example]];
-        } elseif ($response->schema !== null) {
-            $body['content'] = [$mediaType => ['schema' => $this->responseSchema($response)]];
-        } elseif ($response->type !== null && ($typeSchema = TypeStringParser::parse($response->type)) !== null) {
-            $body['content'] = [$mediaType => ['schema' => $this->normalizeSchema($typeSchema)]];
-        } elseif ($response->resource !== null) {
-            $body['content'] = [$mediaType => ['schema' => ['type' => 'object']]];
+            $content['example'] = $response->example;
+        }
+
+        if ($content !== []) {
+            $body['content'] = [$mediaType => $content];
         }
 
         if ($response->headers !== []) {
@@ -514,8 +534,11 @@ final class OpenApiGenerator
 
     private function normalizePath(string $uri): string
     {
-        // Laravel optional params ({id?}) aren't valid OpenAPI path templates.
-        return '/'.ltrim(str_replace('?}', '}', $uri), '/');
+        // Laravel optional params ({id?}) and binding fields ({post:slug})
+        // aren't valid OpenAPI path templates.
+        $path = (string) preg_replace('/\{(\w+)(?::[^}?]+)?\??\}/', '{$1}', $uri);
+
+        return '/'.ltrim($path, '/');
     }
 
     private function sectionFor(EndpointData $endpoint): ?string

--- a/src/OpenApi/SchemaSampler.php
+++ b/src/OpenApi/SchemaSampler.php
@@ -33,6 +33,11 @@ final class SchemaSampler
             }
         }
 
+        if (is_array($schema['type'] ?? null)) {
+            $types = array_values(array_filter($schema['type'], fn (mixed $type): bool => $type !== 'null'));
+            $schema['type'] = $types[0] ?? 'null';
+        }
+
         return match ($schema['type'] ?? null) {
             'object' => self::object($schema, $depth),
             'array' => array_fill(0, max(1, (int) ($schema['minItems'] ?? 1)), self::sample($schema['items'] ?? [], $depth + 1, $name)),

--- a/src/Postman/PostmanGenerator.php
+++ b/src/Postman/PostmanGenerator.php
@@ -26,7 +26,9 @@ final class PostmanGenerator
         $servers = $openapi['servers'] ?? [];
         $baseUrl = $servers[0]['url'] ?? 'http://localhost';
         $rootSecurity = $openapi['security'] ?? [];
-        $securitySchemes = $openapi['components']['securitySchemes'] ?? [];
+        // components.securitySchemes is emitted as a stdClass (so an empty map
+        // serializes to `{}`); cast back to an array for the array-typed helpers.
+        $securitySchemes = (array) ($openapi['components']['securitySchemes'] ?? []);
 
         $folders = [];
         foreach ($openapi['paths'] ?? [] as $path => $operations) {
@@ -100,6 +102,11 @@ final class PostmanGenerator
                 'raw' => json_encode(SchemaSampler::sample($content['application/json']['schema']), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
                 'options' => ['raw' => ['language' => 'json']],
             ];
+        } elseif (isset($content['multipart/form-data']['schema']) && is_array($content['multipart/form-data']['schema'])) {
+            $body = [
+                'mode' => 'formdata',
+                'formdata' => $this->formData($content['multipart/form-data']['schema']),
+            ];
         }
 
         $request = [
@@ -128,6 +135,54 @@ final class PostmanGenerator
             'request' => $request,
             'response' => [],
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<int, array<string, mixed>>
+     */
+    private function formData(array $schema): array
+    {
+        $fields = [];
+
+        foreach (($schema['properties'] ?? []) as $name => $property) {
+            if (! is_string($name) || ! is_array($property)) {
+                continue;
+            }
+
+            if ($this->isFileSchema($property)) {
+                $fields[] = [
+                    'key' => $name,
+                    'type' => 'file',
+                    'src' => '',
+                ];
+
+                continue;
+            }
+
+            $value = SchemaSampler::sample($property, name: $name);
+            $fields[] = [
+                'key' => $name,
+                'type' => 'text',
+                'value' => is_scalar($value) ? (string) $value : json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     */
+    private function isFileSchema(array $schema): bool
+    {
+        if (($schema['format'] ?? null) === 'binary') {
+            return true;
+        }
+
+        return ($schema['type'] ?? null) === 'array'
+            && is_array($schema['items'] ?? null)
+            && ($schema['items']['format'] ?? null) === 'binary';
     }
 
     /**

--- a/src/Support/OpenApiValidator.php
+++ b/src/Support/OpenApiValidator.php
@@ -18,6 +18,7 @@ final class OpenApiValidator
     public static function validate(array $spec): array
     {
         $errors = [];
+        $operationIds = [];
 
         if (($spec['openapi'] ?? null) !== '3.1.0') {
             $errors[] = 'openapi must be 3.1.0';
@@ -44,7 +45,8 @@ final class OpenApiValidator
                 continue;
             }
 
-            $errors = array_merge($errors, self::validatePathItem($spec, $path, $pathItem));
+            $pathErrors = self::validatePathItem($spec, $path, $pathItem, $operationIds);
+            $errors = array_merge($errors, $pathErrors);
         }
 
         return $errors;
@@ -55,10 +57,11 @@ final class OpenApiValidator
      * @param  array<string, mixed>  $pathItem
      * @return array<int, string>
      */
-    private static function validatePathItem(array $spec, string $path, array $pathItem): array
+    private static function validatePathItem(array $spec, string $path, array $pathItem, array &$operationIds): array
     {
         $errors = [];
         $verbs = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'];
+        $templateParameters = self::pathTemplateParameters($path);
 
         foreach ($pathItem as $verb => $operation) {
             if (! in_array($verb, $verbs, true)) {
@@ -75,6 +78,18 @@ final class OpenApiValidator
                 $errors[] = strtoupper((string) $verb)." {$path} must define responses";
             }
 
+            if (is_string($operation['operationId'] ?? null) && $operation['operationId'] !== '') {
+                $operationId = $operation['operationId'];
+
+                if (isset($operationIds[$operationId])) {
+                    $errors[] = "duplicate operationId {$operationId} on ".strtoupper((string) $verb)." {$path}";
+                }
+
+                $operationIds[$operationId] = true;
+            }
+
+            $definedPathParameters = [];
+
             foreach ($operation['parameters'] ?? [] as $parameter) {
                 if (! is_array($parameter)) {
                     $errors[] = strtoupper((string) $verb)." {$path} parameter must be an object";
@@ -90,8 +105,28 @@ final class OpenApiValidator
                     $errors[] = strtoupper((string) $verb)." {$path} path parameter {$parameter['name']} must be required";
                 }
 
+                if (($parameter['in'] ?? null) === 'path' && is_string($parameter['name'] ?? null)) {
+                    $definedPathParameters[$parameter['name']] = true;
+                }
+
                 if (is_array($parameter['schema'] ?? null)) {
                     $errors = array_merge($errors, self::validateSchema($spec, "{$verb} {$path} parameter {$parameter['name']}", $parameter['schema']));
+                }
+            }
+
+            foreach ($templateParameters as $name) {
+                if (! self::validPathParameterName($name)) {
+                    $errors[] = strtoupper((string) $verb)." {$path} path template parameter {$name} is not a valid OpenAPI parameter name";
+                }
+
+                if (! isset($definedPathParameters[$name])) {
+                    $errors[] = strtoupper((string) $verb)." {$path} is missing path parameter {$name}";
+                }
+            }
+
+            foreach (array_keys($definedPathParameters) as $name) {
+                if (! in_array($name, $templateParameters, true)) {
+                    $errors[] = strtoupper((string) $verb)." {$path} defines path parameter {$name} that is not present in the path template";
                 }
             }
 
@@ -111,6 +146,21 @@ final class OpenApiValidator
         }
 
         return $errors;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function pathTemplateParameters(string $path): array
+    {
+        preg_match_all('/\{([^}]+)\}/', $path, $matches);
+
+        return array_values(array_unique($matches[1]));
+    }
+
+    private static function validPathParameterName(string $name): bool
+    {
+        return preg_match('/^[A-Za-z0-9_.-]+$/', $name) === 1;
     }
 
     /**

--- a/tests/Browser/built-in-ui.visual.spec.mjs
+++ b/tests/Browser/built-in-ui.visual.spec.mjs
@@ -48,7 +48,68 @@ function spec(count = 650) {
   };
 }
 
-async function mount(page) {
+function multipartSpec() {
+  return {
+    openapi: '3.1.0',
+    info: { title: 'Upload API', version: '1.0.0' },
+    servers: [{ url: 'http://documentator.test' }],
+    paths: {
+      '/api/uploads': {
+        post: {
+          operationId: 'uploadAvatar',
+          tags: ['Uploads'],
+          summary: 'Upload avatar',
+          requestBody: {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    avatar: { type: 'string', format: 'binary' },
+                    items: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          sku: { type: 'string' },
+                          qty: { type: 'integer' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: { 200: { description: 'OK' } },
+        },
+      },
+    },
+  };
+}
+
+function cookieSpec() {
+  return {
+    openapi: '3.1.0',
+    info: { title: 'Cookie API', version: '1.0.0' },
+    servers: [{ url: 'http://documentator.test' }],
+    paths: {
+      '/api/cookie': {
+        get: {
+          operationId: 'cookieCheck',
+          tags: ['Auth'],
+          summary: 'Cookie check',
+          parameters: [
+            { name: 'session_id', in: 'cookie', schema: { type: 'string' } },
+          ],
+          responses: { 200: { description: 'OK' } },
+        },
+      },
+    },
+  };
+}
+
+async function mount(page, openapi = spec()) {
   const [css, js, core, snippets] = await Promise.all([
     readFile(resolve(root, 'resources/ui/app.css'), 'utf8'),
     readFile(resolve(root, 'resources/ui/app.js'), 'utf8'),
@@ -58,7 +119,7 @@ async function mount(page) {
 
   await page.route('http://documentator.test/docs/openapi.json', route => route.fulfill({
     contentType: 'application/json',
-    body: JSON.stringify(spec()),
+    body: JSON.stringify(openapi),
   }));
   await page.route('http://documentator.test/docs/assets/app.css', route => route.fulfill({
     contentType: 'text/css',
@@ -157,4 +218,30 @@ test('mobile layout exposes the sidebar without overlapping the document', async
   expect(sidebar.width).toBeGreaterThan(250);
   expect(doc.width).toBeGreaterThan(0);
   expect((await page.locator('#app').screenshot()).length).toBeGreaterThan(20000);
+});
+
+test('multipart snippets use Laravel-compatible bracket field names for nested values', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 860 });
+  await mount(page, multipartSpec());
+  await page.locator('.nav-item').first().click();
+
+  await expect(page.locator('#snippetCode')).toContainText('items[0][sku]=string');
+  await expect(page.locator('#snippetCode')).toContainText('items[0][qty]=0');
+});
+
+test('cookie parameters are applied through browser cookies on same-origin requests', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 860 });
+  let cookieHeader = '';
+
+  await page.route('http://documentator.test/api/cookie', route => {
+    cookieHeader = route.request().headers().cookie || '';
+    return route.fulfill({ contentType: 'application/json', body: '{"ok":true}' });
+  });
+
+  await mount(page, cookieSpec());
+  await page.locator('.nav-item').first().click();
+  await page.locator('[data-kind="cookie"][data-name="session_id"]').fill('abc123');
+  await page.locator('#send').click();
+
+  await expect.poll(() => cookieHeader).toContain('session_id=abc123');
 });

--- a/tests/Feature/AdvancedInferenceTest.php
+++ b/tests/Feature/AdvancedInferenceTest.php
@@ -75,6 +75,12 @@ class AdvancedInferenceController
         return new AdvancedInvoiceResource([]);
     }
 
+    #[Response(200, type: 'array{id: int, status: string}', example: ['id' => 10, 'status' => 'queued'])]
+    public function responseExampleAndType(): void
+    {
+        //
+    }
+
     public function queryBuilder(): void
     {
         $filters = ['name', AllowedFilter::exact('id'), AllowedFilter::exact('published')->ignore('all')];
@@ -137,6 +143,17 @@ it('emits operation, header, media type, response header, and schema name attrib
         ->and($operation['responses']['202']['content']['application/json']['schema']['properties']['status']['type'])->toBe('string')
         ->and($operation['responses']['202']['content']['application/json']['schema']['required'])->not->toContain('status')
         ->and($operation['responses']['202']['content']['application/json']['schema']['properties']['meta']['properties']['queued_at']['type'])->toBe(['string', 'null']);
+});
+
+it('keeps response schemas when an explicit example is also provided', function () {
+    Route::get('api/advanced/example-schema', [AdvancedInferenceController::class, 'responseExampleAndType']);
+
+    $media = app(Documentator::class)
+        ->toOpenApi()['paths']['/api/advanced/example-schema']['get']['responses']['200']['content']['application/json'];
+
+    expect($media['example'])->toBe(['id' => 10, 'status' => 'queued'])
+        ->and($media['schema']['properties']['id']['type'])->toBe('integer')
+        ->and($media['schema']['properties']['status']['type'])->toBe('string');
 });
 
 it('infers Spatie Query Builder filter, sort, include, and field query parameters from literal allowed calls', function () {

--- a/tests/Feature/InferenceAccuracyTest.php
+++ b/tests/Feature/InferenceAccuracyTest.php
@@ -106,6 +106,28 @@ it('types an implicitly model-bound path parameter from the model key', function
         ->and($param['schema']['type'])->toBe('integer');
 });
 
+it('normalizes custom Laravel route binding fields in OpenAPI paths', function () {
+    Route::get('api/products/{product:slug}', [AccuracyController::class, 'bound']);
+
+    $paths = app(Documentator::class)->toOpenApi()['paths'];
+    $param = $paths['/api/products/{product}']['get']['parameters'][0];
+
+    expect($paths)->toHaveKey('/api/products/{product}')
+        ->and($paths)->not->toHaveKey('/api/products/{product:slug}')
+        ->and($param['name'])->toBe('product')
+        ->and($param['schema']['type'])->toBe('string');
+});
+
+it('keeps generated operation ids unique when routes share a controller action', function () {
+    Route::get('api/things/{id}', [AccuracyController::class, 'show']);
+    Route::get('api/widgets/{id}', [AccuracyController::class, 'show']);
+
+    $paths = app(Documentator::class)->toOpenApi()['paths'];
+
+    expect($paths['/api/things/{id}']['get']['operationId'])
+        ->not->toBe($paths['/api/widgets/{id}']['get']['operationId']);
+});
+
 it('infers a response schema from a Model return type using its casts', function () {
     Route::get('api/fetch', [AccuracyController::class, 'fetch']);
 

--- a/tests/Feature/OpenApiValidationTest.php
+++ b/tests/Feature/OpenApiValidationTest.php
@@ -64,3 +64,38 @@ it('reports invalid refs and legacy nullable schemas', function () {
         'get /api/broken response 200 application/json has an unresolved ref #/components/schemas/Missing',
     );
 });
+
+it('reports path parameter mismatches and duplicate operation ids', function () {
+    $spec = [
+        'openapi' => '3.1.0',
+        'info' => ['title' => 'API', 'version' => '1.0.0'],
+        'paths' => [
+            '/api/posts/{post:slug}' => [
+                'get' => [
+                    'operationId' => 'showPost',
+                    'parameters' => [],
+                    'responses' => ['200' => ['description' => 'ok']],
+                ],
+            ],
+            '/api/articles/{article}' => [
+                'get' => [
+                    'operationId' => 'showPost',
+                    'parameters' => [
+                        ['name' => 'unused', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
+                    ],
+                    'responses' => ['200' => ['description' => 'ok']],
+                ],
+            ],
+        ],
+    ];
+
+    $errors = OpenApiValidator::validate($spec);
+
+    expect($errors)->toContain(
+        'GET /api/posts/{post:slug} path template parameter post:slug is not a valid OpenAPI parameter name',
+        'GET /api/posts/{post:slug} is missing path parameter post:slug',
+        'GET /api/articles/{article} is missing path parameter article',
+        'GET /api/articles/{article} defines path parameter unused that is not present in the path template',
+        'duplicate operationId showPost on GET /api/articles/{article}',
+    );
+});

--- a/tests/Feature/PaginationAndExamplesTest.php
+++ b/tests/Feature/PaginationAndExamplesTest.php
@@ -28,6 +28,7 @@ class ExampleRequest extends FormRequest
         return [
             'email' => 'required|email',
             'age' => 'required|integer|min:21',
+            'score' => 'nullable|integer|min:5',
         ];
     }
 }
@@ -63,7 +64,8 @@ it('generates format-aware examples for the request body', function () {
     $example = $body['content']['application/json']['example'];
 
     expect($example['email'])->toBe('user@example.com')
-        ->and($example['age'])->toBe(21); // honours the min bound
+        ->and($example['age'])->toBe(21) // honours the min bound
+        ->and($example['score'])->toBe(5); // samples the non-null side of OpenAPI 3.1 unions
 });
 
 it('omits generated examples when disabled', function () {

--- a/tests/Feature/PostmanTest.php
+++ b/tests/Feature/PostmanTest.php
@@ -98,3 +98,39 @@ it('maps OpenAPI security requirements to Postman auth', function () {
         ->and($requests[1]['request'])->not->toHaveKey('auth')
         ->and($requests[2]['request']['auth']['type'])->toBe('basic');
 });
+
+it('exports multipart request bodies as Postman form data', function () {
+    $openapi = [
+        'info' => ['title' => 'Acme'],
+        'paths' => [
+            '/api/uploads' => [
+                'post' => [
+                    'tags' => ['Uploads'],
+                    'summary' => 'Upload avatar',
+                    'requestBody' => [
+                        'content' => [
+                            'multipart/form-data' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'required' => ['avatar'],
+                                    'properties' => [
+                                        'avatar' => ['type' => 'string', 'format' => 'binary'],
+                                        'name' => ['type' => 'string', 'example' => 'Ada'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'responses' => ['200' => ['description' => 'ok']],
+                ],
+            ],
+        ],
+    ];
+
+    $request = (new PostmanGenerator)->generate($openapi)['item'][0]['item'][0]['request'];
+    $form = collect($request['body']['formdata'])->keyBy('key');
+
+    expect($request['body']['mode'])->toBe('formdata')
+        ->and($form['avatar']['type'])->toBe('file')
+        ->and($form['name']['value'])->toBe('Ada');
+});


### PR DESCRIPTION
## Summary

fixed Custom route binding fields produce valid path templates
fixed Postman export handles an empty security-scheme map

## Checklist

- [ ] Tests added or updated, if behavior changed
- [ ] `composer test` passes
- [ ] `composer lint:test` passes
- [ ] Documentation updated, if needed
- [ ] Security impact considered
