### PR TITLE
Release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-07-16
+
+### Fixed
+
+- **Release history validation.** Restored the missing 2.0.1 changelog entry so
+  release tags and the documented package history remain aligned.
+
+## [2.0.1] - 2026-07-16
+
+### Changed
+
+- **Softer explorer theme.** Refined the built-in explorer's dark surfaces,
+  borders, shadows, and response panels for a lighter visual treatment.
+- **Consistent text files.** Enabled automatic text detection and LF line-ending
+  normalization through `.gitattributes`.
+
 ## [2.0.0] - 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1] - 2026-07-16
+## [2.0.0] - 2026-07-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-07-16
+## [2.0.1] - 2026-07-16
 
 ### Added
 


### PR DESCRIPTION
## Summary

- restore the missing v2.0.1 release history
- document the v2.0.2 release metadata correction
- ensure the release-tag changelog validation passes before tagging

## Verification

- `composer validate --strict --no-check-publish`
- release changelog checks for v2.0.1 and v2.0.2